### PR TITLE
Multimodem fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,18 @@ rapidsms-multimodem is released under the BSD License. See the  `LICENSE
 <https://github.com/caktus/rapidsms-multimodem/blob/master/LICENSE.txt>`_ file
 for more details.
 
+Settings
+--------
+
+"multimodem-1": {
+"ENGINE": "rapidsms_multimodem.outgoing.MultiModemBackend",
+    "sendsms_url": "http://192.168.170.200:81/sendmsg",
+    "sendsms_user": "admin",
+    "sendsms_pass": "admin",
+    "sendsms_params": { "modem": 1 },
+},
+
+
 Contributing
 ------------
 

--- a/rapidsms_multimodem/tests.py
+++ b/rapidsms_multimodem/tests.py
@@ -7,7 +7,56 @@ from rapidsms.tests.harness import RapidTest
 from rapidsms_multimodem.views import MultiModemView
 
 
-VALID_POST = """<?xml version="1.0" encoding="ISO-8859-1"?>
+VALID_POST = """
+<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>
+<Response>
+    <Msg_Count>1</Msg_Count>
+    <MessageNotification>
+        <Message_Index>1</Message_Index>
+        <ModemNumber>2:111222333</ModemNumber>
+        <SenderNumber>+222333444</SenderNumber>
+        <Date>15/04/13</Date>
+        <Time>10:54:27</Time>
+        <EncodingFlag>ASCII</EncodingFlag>
+        <Message>Test</Message>
+    </MessageNotification>
+</Response>
+<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>
+<Response>
+    <Msg_Count>2</Msg_Count>
+    <MessageNotification>
+        <Message_Index>1</Message_Index>
+        <ModemNumber>2:380665717968</ModemNumber>
+        <SenderNumber>+380990405272</SenderNumber>
+        <Date>15/04/13</Date>
+        <Time>10:55:58</Time>
+        <EncodingFlag>ASCII</EncodingFlag>
+        <Message>Testn2</Message>
+    </MessageNotification>
+        <MessageNotification>
+        <Message_Index>2</Message_Index>
+        <ModemNumber>2:380665717968</ModemNumber>
+        <SenderNumber>+380990405272</SenderNumber>
+        <Date>15/04/13</Date>
+        <Time>10:58:39</Time>
+        <EncodingFlag>Unicode</EncodingFlag>
+        <Message>0429043D043F0437043D043C0433043C0436043D043C</Message>
+    </MessageNotification>
+</Response>
+<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>
+<Response>
+    <Msg_Count>1</Msg_Count>
+    <MessageNotification>
+        <Message_Index>1</Message_Index>
+        <ModemNumber>2:380665717968</ModemNumber>
+        <SenderNumber>+380990405272</SenderNumber>
+        <Date>15/04/13</Date>
+        <Time>11:01:16</Time>
+        <EncodingFlag>Unicode</EncodingFlag>
+        <Message>00C90020006F002000660069006D00200064006F0020006D0075006E0064006F002C002000650020006E00E3006F0020006D006500200069006D0070006F007200740061002E0020</Message>
+    </MessageNotification>
+</Response>
+<?xml version="1.0" encoding="ISO-8859-1"?>
 <Response>
 <MessageNotification>
 <ModemNumber>2:19525945092</ModemNumber>

--- a/rapidsms_multimodem/utils.py
+++ b/rapidsms_multimodem/utils.py
@@ -41,6 +41,7 @@ def isms_urlencode(query):
     """Encode a sequence of two-element tuples into a URL query string.
 
     Customized because `text` parameter must have space characters quoted with %20 instead of +
+    Everything else has to be encoded with quote_plus
     """
     parts = []
     for k, v in query.items():

--- a/rapidsms_multimodem/utils.py
+++ b/rapidsms_multimodem/utils.py
@@ -37,7 +37,7 @@ def ismsformat_to_unicode(byte_str):
     return unicode_str
 
 
-def isms_urlencode(self, query):
+def isms_urlencode(query):
     """Encode a sequence of two-element tuples into a URL query string.
 
     Customized because `text` parameter must have space characters quoted with %20 instead of +

--- a/rapidsms_multimodem/views.py
+++ b/rapidsms_multimodem/views.py
@@ -79,7 +79,7 @@ def receive_multimodem_message(request):
             Two iSMS servers would have the same modem number.
             Another solution would be to add the phone number to the settings.
             """
-            backend_names = [backend[1] for backend in possible_backends
+            backend_names = [backend[0] for backend in possible_backends
                              if 'sendsms_params' in backend[1]
                              and 'modem' in backend[1]['sendsms_params']
                              and int(backend[1]['sendsms_params']['modem']) == int(modem_number)]

--- a/rapidsms_multimodem/views.py
+++ b/rapidsms_multimodem/views.py
@@ -79,7 +79,7 @@ def receive_multimodem_message(request):
             Two iSMS servers would have the same modem number.
             Another solution would be to add the phone number to the settings.
             """
-            backend_names = [backend for backend in possible_backends
+            backend_names = [backend[1] for backend in possible_backends
                              if 'sendsms_params' in backend[1]
                              and 'modem' in backend[1]['sendsms_params']
                              and int(backend[1]['sendsms_params']['modem']) == int(modem_number)]

--- a/rapidsms_multimodem/views.py
+++ b/rapidsms_multimodem/views.py
@@ -1,38 +1,100 @@
 import logging
 import xml.etree.ElementTree as ET
 
+from django.conf import settings
 from rapidsms.backends.http.views import GenericHttpBackendView
 
+from django.http import HttpResponse, HttpResponseServerError
+from django.views.decorators.csrf import csrf_exempt
 from .utils import ismsformat_to_unicode
 
+from rapidsms.router import receive
+from rapidsms.router import lookup_connections
 logger = logging.getLogger(__name__)
 
 
-class MultiModemView(GenericHttpBackendView):
+@csrf_exempt
+def receive_multimodem_message(request):
     """
-    Backend view for processing incoming messages from MultiModem iSMS.
+    The view to handle requests from multimodem has to be custom because the server can post 1-* messages in a single
+    request. The Rapid built-in class-based views only accept a single message per form/post.
+
+    TODO:
+    Add basic auth to validate against Rapid's user database. The iSMS modem only supports basic auth.
+
+    :param request:
+    :return:
+    """
+    xml_data = request.POST['XMLDATA']
+    """
+    The modem posts the data as it receives it formatted as an xml file. The xml is then URL encoded and posted as a
+    form parameter called XML data.
+
+    Decoded Example:
+    <?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>
+    <Response>
+        <Msg_Count>2</Msg_Count>
+        <MessageNotification>
+            <Message_Index>1</Message_Index>
+            <ModemNumber>2:111222333</ModemNumber>
+            <SenderNumber>+222333333</SenderNumber>
+            <Date>15/04/13</Date>
+            <Time>10:55:58</Time>
+            <EncodingFlag>ASCII</EncodingFlag>
+            <Message>Testn2</Message>
+        </MessageNotification>
+            <MessageNotification>
+            <Message_Index>2</Message_Index>
+            <ModemNumber>2:111222333</ModemNumber>
+            <SenderNumber>+222333333</SenderNumber>
+            <Date>15/04/13</Date>
+            <Time>10:58:39</Time>
+            <EncodingFlag>Unicode</EncodingFlag>
+            <Message>0429043D043F0437043D043C0433043C0436043D043C</Message>
+        </MessageNotification>
+    </Response>
     """
 
-    http_method_names = ['post']
+    try:
+        root = ET.fromstring(xml_data)
+    except ET.ParseError:
+        logger.error("Failed to parse XML")
+        logger.error(request.body)
+        return HttpResponseServerError('Error parsing XML')
 
-    def get_form_kwargs(self):
-        """Load XML POST data."""
-        kwargs = super(MultiModemView, self).get_form_kwargs()
-        xml = kwargs['data']['XMLDATA']
-        try:
-            root = ET.fromstring(xml)
-        except ET.ParseError:
-            logger.error("Failed to parse XML")
-            logger.error(self.request.body)
+    for message in root.findall('MessageNotification'):
+        raw_text = message.find('Message').text
+        from_number = message.find('ModemNumber').text
+        """
+        Once we have the modem number we have to try to find its matching backend.
+        Unfortunately, I'll have to dig through the settings.
+        """
+        if ':' in from_number:
+            modem_number, phone_number = from_number.split(':')[0:2]
 
-        for message in root.findall('MessageNotification'):
-            raw_text = message.find('Message').text
-            encoding = message.find('EncodingFlag').text
-            if encoding == "Unicode":
-                msg_text = ismsformat_to_unicode(raw_text)
-            else:
-                msg_text = raw_text
-            data = {'text': msg_text,
-                    'identity': message.find('SenderNumber').text}
-        kwargs['data'] = data
-        return kwargs
+            possible_backends = getattr(settings, 'INSTALLED_BACKENDS', {}).items()
+            """
+            Obviously this needs refactoring.
+
+            Two iSMS servers would have the same modem number.
+            Another solution would be to add the phone number to the settings.
+            """
+            backend_names = [backend for backend in possible_backends
+                             if 'sendsms_params' in backend[1]
+                             and 'modem' in backend[1]['sendsms_params']
+                             and int(backend[1]['sendsms_params']['modem']) == int(modem_number)]
+            if possible_backends:
+                backend_name = backend_names[0]
+                encoding = message.find('EncodingFlag').text
+                if encoding.lower() == "unicode":
+                    msg_text = ismsformat_to_unicode(raw_text)
+                else:
+                    msg_text = raw_text
+
+                connections = lookup_connections(backend_name, [message.find('SenderNumber').text])
+                data = {'text': msg_text,
+                        'connection': connections[0]}
+                receive(**data)
+
+    return HttpResponse('OK')
+


### PR DESCRIPTION
Quoting from Rey:

I was going through the workflow here in Ukraine, and what I found out is that the modem groups messages into one single post back to the application. I'm not sure if there is a setting in the server to decouple that, but the code ignored all messages but the last one.

There was also an issue with the multiple modems inside the iSMS server, the information of where the message is coming from is part of the payload of the message.

Because I had to parse out multiple messages per HTTP POST as well as look for the backend based on the xml of each message (I haven't tested it thoroughly, but in theory the server could send one XML file with multiple messages, one from each physical modem), I ended up removing the class-based view from the code and I reimplemented that part from scratch.

Not very pythonic, I know, but I am sure we ​will​ see this issue as soon as we go live anywhere else with those modems and I wanted to get the conversation going as to how to make this more future proof.

The good news now, though, is that the backend should be able to work with the multitenant infrastructure, and it will route the messages to the right backend depending on the settings of the backend.

-- endquote
