### PR TITLE
Allow messages from multiple iSMS servers to be captured properly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,13 +16,33 @@ for more details.
 Settings
 --------
 
-"multimodem-1": {
-"ENGINE": "rapidsms_multimodem.outgoing.MultiModemBackend",
-    "sendsms_url": "http://192.168.170.200:81/sendmsg",
-    "sendsms_user": "admin",
-    "sendsms_pass": "admin",
-    "sendsms_params": { "modem": 1 },
-},
+The following parameters are required: ``sendsms_url``, ``sendsms_user``, ``sendsms_pass``,
+``modem_port``, and ``server_slug``::
+
+  "multimodem-1": {
+      "ENGINE": "rapidsms_multimodem.outgoing.MultiModemBackend",
+      "sendsms_url": "http://192.168.170.200:81/sendmsg",
+      "sendsms_user": "admin",
+      "sendsms_pass": "admin",
+      "modem_port": 1,
+      "server_slug": "isms-lebanon",
+  },
+
+Single port modems only have 1 port, but it should still be specified.
+
+The ``server_slug`` parameter serves 2 purposes. It uniquely identifies the iSMS server, so that
+RapidSMS doesn't get confused by 2 different servers having the same port number (since those are
+restricted to be integers from 1 to 8). It's also used to create the RapidSMS URL that the iSMS
+server will send messages to. Your ``urls.py`` should look something like this::
+
+  urlpatterns = [
+      url(r"^backend/multimodem/(?P<server_slug>[\w_-]+)/$",
+          receive_multimodem_message,
+          name='multimodem-backend'),
+  ]
+
+With the 2 code examples above, your iSMS server should POST messages to
+http://your-rapidsms-server.example.com/backend/multimodem/isms-lebanon/.
 
 
 Contributing

--- a/rapidsms_multimodem/outgoing.py
+++ b/rapidsms_multimodem/outgoing.py
@@ -15,11 +15,13 @@ ISMS_UNICODE = 2
 class MultiModemBackend(BackendBase):
     """Outgoing SMS backend for MultiModem iSMS."""
 
-    def configure(self, sendsms_url, sendsms_user, sendsms_pass,
-                  sendsms_params=None, **kwargs):
+    def configure(self, sendsms_url, sendsms_user, sendsms_pass, modem_port,
+                  server_slug, sendsms_params=None):
         self.sendsms_url = sendsms_url
         self.sendsms_user = sendsms_user
         self.sendsms_pass = sendsms_pass
+        self.modem_port = modem_port
+        self.server_slug = server_slug
         self.sendsms_params = sendsms_params or {}
 
     def prepare_querystring(self, id_, text, identities, context):
@@ -31,7 +33,7 @@ class MultiModemBackend(BackendBase):
         params['passwd'] = self.sendsms_pass
         params['cat'] = 1
         params['enc'] = ISMS_ASCII
-        params['modem'] = self.sendsms_params.get('modem', 0)
+        params['modem'] = self.modem_port
         params['to'] = to
         # 'text' is tricky. iSMS has 3 encodings: ascii, enhanced ascii, and 'unicode'
         # (Note: it's not really Unicode, but a iSMS custom binary format)

--- a/rapidsms_multimodem/tests/test_outgoing.py
+++ b/rapidsms_multimodem/tests/test_outgoing.py
@@ -16,7 +16,8 @@ class SendTest(CreateDataMixin, TestCase):
             'sendsms_url': 'http://192.168.170.200:81/sendmsg',
             'sendsms_user': 'admin',
             'sendsms_pass': 'admin',
-            'sendsms_params': {'modem': 1},
+            'modem_port': 1,
+            'server_slug': 'isms-lebanon',
         }
         self.backend = MultiModemBackend(None, "multimodem", **config)
 

--- a/rapidsms_multimodem/tests/urls.py
+++ b/rapidsms_multimodem/tests/urls.py
@@ -3,5 +3,7 @@ from django.conf.urls import url
 from rapidsms_multimodem.views import receive_multimodem_message
 
 urlpatterns = [
-    url(r"^backend/multimodem/$", receive_multimodem_message, name='multimodem-backend'),
+    url(r"^backend/multimodem/(?P<server_slug>[\w_-]+)/$",
+        receive_multimodem_message,
+        name='multimodem-backend'),
 ]


### PR DESCRIPTION
- BACKWARDS INCOMPATIBLE CHANGE: I moved `modem` and `server_slug` out
  of `sendsms_params` since they are required.
- Updated all the docs
